### PR TITLE
Add default headers

### DIFF
--- a/src/Provider/Heroku.php
+++ b/src/Provider/Heroku.php
@@ -80,9 +80,9 @@ class Heroku extends AbstractProvider
      */
     protected function getDefaultHeaders()
     {
-      return [
-        'Accept' => 'application/vnd.heroku+json; version=3'
-      ];
+        return [
+            'Accept' => 'application/vnd.heroku+json; version=3'
+        ];
     }
 
     /**

--- a/src/Provider/Heroku.php
+++ b/src/Provider/Heroku.php
@@ -72,6 +72,20 @@ class Heroku extends AbstractProvider
     }
 
     /**
+     * Returns the default headers used by this provider.
+     *
+     * Typically this is used to set 'Accept' or 'Content-Type' headers.
+     *
+     * @return array
+     */
+    protected function getDefaultHeaders()
+    {
+      return [
+        'Accept' => 'application/vnd.heroku+json; version=3'
+      ];
+    }
+
+    /**
      * Check a provider response for errors.
      *
      * @throws IdentityProviderException


### PR DESCRIPTION
Requests do not longer work because Heroku requires an 'Accept' header. For instance, take a look at [https://devcenter.heroku.com/articles/platform-api-reference#account](https://devcenter.heroku.com/articles/platform-api-reference#account).

In fact, without this header, the API returns the following error
```
Please specify a version along with Heroku's API MIME type. For example, `Accept: application/vnd.heroku+json; version=3
```